### PR TITLE
Replace 'keep_dims' with 'keepdims'

### DIFF
--- a/dsnt.py
+++ b/dsnt.py
@@ -98,9 +98,9 @@ def _softmax2d(target, axes):
         targets - The tensor on which to apply softmax
         axes - An integer or list of integers across which to apply softmax
     '''
-    max_axis = tf.reduce_max(target, axes, keep_dims=True)
+    max_axis = tf.reduce_max(target, axes, keepdims=True)
     target_exp = tf.exp(target-max_axis)
-    normalize = tf.reduce_sum(target_exp, axes, keep_dims=True)
+    normalize = tf.reduce_sum(target_exp, axes, keepdims=True)
     softmax = target_exp / normalize
     return softmax
 


### PR DESCRIPTION
This change resolves the following warnings from Tensorflow.

```
WARNING:tensorflow:From dsnt.py:101: calling reduce_max (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
WARNING:tensorflow:From dsnt.py:103: calling reduce_sum (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.
Instructions for updating:
keep_dims is deprecated, use keepdims instead
```