### PR TITLE
Fix invalid batch size in reshape operation

### DIFF
--- a/dsnt.py
+++ b/dsnt.py
@@ -62,7 +62,7 @@ def _normalise_heatmap(inputs, method='softmax'):
     inputs = tf.reshape(inputs, tf.shape(inputs)[:3])
 
     # Normalise the values such that the values sum to one for each heatmap
-    normalise = lambda x: tf.div(x, tf.reshape(tf.reduce_sum(x, [1, 2]), [2, 1, 1]))
+    normalise = lambda x: tf.div(x, tf.reshape(tf.reduce_sum(x, [1, 2]), [-1, 1, 1]))
 
     # Perform rectification
     if method == 'softmax':


### PR DESCRIPTION
If a method other than softmax is used, normalization is applied, which attempts to convert the reduced sums for the current batch to a fixed batch size of 2.

I patched it so it resizes to an arbitrary batch size.